### PR TITLE
Fix link header generation

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -291,11 +291,12 @@ function setupRest(app) {
 								server.uri.indexOf('turn:') !== 0 &&
 								server.uri.indexOf('turns:') !== 0))
 							continue;
-						let link = '<' + server.uri + '>; rel="ice-server";';
+						let link = '<' + server.uri + '>; rel="ice-server"';
 						if(server.username && server.credential) {
+							link += ';'
 							link += ' username="' + server.username + '";' +
 								' credential="' + server.credential + '";' +
-								' credential-type: "password";';
+								' credential-type="password"';
 						}
 						links.push(link);
 					}


### PR DESCRIPTION
This demo Server appends an extra ; at the end of each link which is not needed as per https://www.rfc-editor.org/rfc/rfc8288.html#section-3.5.

Also the credential-type was resulting in a malformed param.