### PR TITLE
Add support for subscriber offer (requires specific version of Janus)

### DIFF
--- a/src/whep-janus.js
+++ b/src/whep-janus.js
@@ -205,6 +205,7 @@ var whepJanus = function(janusConfig) {
 		}
 		let mountpoint = details.mountpoint;
 		let pin = details.pin;
+		let sdp = details.sdp;
 		let uuid = details.uuid;
 		let session = sessions[uuid];
 		if(!session) {
@@ -263,6 +264,10 @@ var whepJanus = function(janusConfig) {
 					pin: pin
 				}
 			};
+			if(sdp) {
+				// We're going to let the user provide the SDP offer
+				subscribe.jsep = { type: 'offer', sdp: sdp };
+			}
 			janusSend(subscribe, function(response) {
 				let event = response["janus"];
 				if(event === "error") {
@@ -284,7 +289,7 @@ var whepJanus = function(janusConfig) {
 					callback({ error: data.error });
 					return;
 				}
-				whep.debug("Got an offer for session " + uuid + ":", data);
+				whep.debug("Got an SDP for session " + uuid + ":", data);
 				if(data["reason"]) {
 					// Unsubscribe from the transaction
 					delete that.config.janus.transactions[response["transaction"]];

--- a/web/watch.js
+++ b/web/watch.js
@@ -225,7 +225,7 @@ function createPeerConnectionIfNeeded(iceServers) {
 		if($('#whepvideo').length === 0) {
 			$('#video').removeClass('hide').show();
 			$('#videoremote').append('<video class="rounded centered" id="whepvideo" width="100%" height="100%" autoplay playsinline/>');
-			$('#whenvideo').get(0).volume = 0;
+			$('#whepvideo').get(0).volume = 0;
 		}
 		attachMediaStream($('#whepvideo').get(0), event.streams[0]);
 		$('#whepvideo').get(0).play();


### PR DESCRIPTION
Unfortunately the [latest version of the WHEP draft](https://author-tools.ietf.org/iddiff?url1=draft-murillo-whep-01&url2=draft-murillo-whep-02&difftype=--html) removed support for server-originated SDP offers, and now forces all servers to accept offers from subscribers instead, leaving servers to generate an answer. This completely breaks compatibility with the Streaming plugin in Janus, which is used for WHEP support in this server and _only_ supports server-originated offers.

I completely disagree with this choice, but my opinion doesn't matter, so I was forced to modify the Streaming plugin to start adding support for this new ugly mode too. This support is currently provided in a [new PR](https://github.com/meetecho/janus-gateway/pull/3199), which means that if you want to test this feature, you'll have to compile Janus from the related branch, and not `master`.

When you do, you can test the offer-mode by passing a `offer=true` query string attribute to the `watch.html` page, e.g.:

    http://localhost:7090/watch.html?id=test&offer=true

When `offer=true` is passed, the viewer page will prepare an offer instead of expecting one, and the WHEP server will handle it accordingly. Again, this will only work if the Janus server the WHEP server is using supports that mode: if you use other versions of Janus, it simply won't work.

Please also test this with other WHEP viewers you may have, if any. My `simple-whep-server` has not been updated yet, and I don't know when I'll do that (if I'll do it at all). Feedback would be welcome.