### PR TITLE
Add framework for SSE support (replaces #3)

### DIFF
--- a/examples/server-owned/src/index.js
+++ b/examples/server-owned/src/index.js
@@ -43,10 +43,20 @@ import { JanusWhepServer } from '../../../src/whep.js';
 
 	// Create a test endpoint using a static token
 	let endpoint = server.createEndpoint({ id: 'abc123', mountpoint: 1, token: 'verysecret' });
-	endpoint.on('new-subscriber', function() {
-		console.log(this.id + ': Endpoint has a new subscriber');
+	endpoint.on('new-subscriber', function(uuid) {
+		console.log(this.id + ': Endpoint has a new subscriber (' + uuid + ')');
+		endpoint.notifySubscribers({ event: 'viewercount', data: ''+endpoint.countSubscribers() });
 	});
-	endpoint.on('subscriber-gone', function() {
-		console.log(this.id + ': Endpoint subscriber left');
+	endpoint.on('subscriber-sse', function(uuid, events) {
+		if(events) {
+			console.log(this.id + ': Subscriber ' + uuid + ' subscribed to SSE:', events);
+			this.getSubscriber({ uuid: uuid }).notify({ event: 'viewercount', data: ''+endpoint.countSubscribers() });
+		} else {
+			console.log(this.id + ': Subscriber ' + uuid + ' unsubscribed from SSE');
+		}
+	});
+	endpoint.on('subscriber-gone', function(uuid) {
+		console.log(this.id + ': Endpoint subscriber left (' + uuid + ')');
+		endpoint.notifySubscribers({ event: 'viewercount', data: ''+endpoint.countSubscribers() });
 	});
 }());

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "janus-whep-server",
 	"description": "Simple Janus-based WHEP server library",
-	"version": "1.0.0",
+	"version": "1.1.0",
 	"type": "module",
 	"keywords": [
 		"whep",


### PR DESCRIPTION
This PR adds support for SSE to the WHEP library, thus replacing the old #3.

It takes a different approach. The old PR tried to do everything: not only dealing with SSE, but also monitoring resources to autonomously decide what to notify and when. I decided to change that, and now the library only provides a framework to advertise SSE support, and negotiate what to notify about via SSE. It then leaves the burden of actually pushing events to notify up to the application.

The demos come with a simple example of how to notify the count of viewers (`viewercount`), since the application is aware of that. The web demo has been updated to visually show the content of SSE events as well, which should make it easy to test.

Considering there are a couple of changes, the version will be bumped to `1.1.0` when this is merged.