### PR TITLE
Added support for more Janus plugins for subscribing, besides the Streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,10 +84,11 @@ The object to pass when creating a new endpoint must refer to the following stru
 ```
 {
 	id: "<unique ID of the endpoint to create>",
-	mountpoint: <Streaming mountpoint ID to subscribe to>,
-	pin: <Streaming mountpoint pin, if required to subscribe (optional)>,
-	label: <Label to show when subscribing (optional, only relevant in the demo)>,
-	token: "<token to require via Bearer authorization when using WHIP: can be either a string, or a callback function to validate the provided token (optional)>,
+	plugin: "<ID of the Janus plugin to subscribe to (optional, default=streaming; supported=videoroom,recordplay)>",
+	mountpoint: <Plugin resource to subscribe to (e.g., Streaming mountpoint ID)>,
+	pin: <Resource pin, if required to subscribe (optional)>,
+	label: "<Label to show when subscribing (optional, only relevant in the demo)>",
+	token: "<token to require via Bearer authorization when using WHIP: can be either a string, or a callback function to validate the provided token (optional)>",
 	iceServers: [ array of STUN/TURN servers to return via Link headers (optional, overrides global ones) ]
 }
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -7,8 +7,14 @@ This folder contains a few example applications using the Janus WHEP library.
 
 * The `server-shared` folder, instead, contains an example where the application pre-creates a REST server for its own needs, and then tells the library to re-use that server for the WHEP functionality too. A sample endpoint is created, with a callback function used to validate the token any time one is presented.
 
-Both demos subscribe to a few of the events the library can emit for debugging purposes, and serve the `web` folder as static file, which provides a basic WHEP player. Assuming the endpoint `abc123` is available at the WHEP server, you can watch it like that:
+* The `videoroom` folder shows how you can configure a WHEP endpoint to rely on the VideoRoom plugin, instead of the Streaming (which is the default), thus simply subscribing to an existing and active publisher in a room.
+
+* The `recordplay` folder shows how you can configure a WHEP endpoint to rely on the RecordPlay plugin, instead of the Streaming (which is the default), thus simply playing an existing Janus recording.
+
+All demos subscribe to a few of the events the library can emit for debugging purposes, and serve the `web` folder as static file, which provides a basic WHEP player. Assuming the endpoint `abc123` is available at the WHEP server, you can watch it like that:
 
 	http://localhost:PORT/?id=abc123
 
-where `PORT` is `7190` in the `server-owned` example, and `7090` in the `server-shared` example. Notice that, should you want Janus to send the offer (non-standard WHEP), you can do that by passing an additional `offer=false` to the query string.
+where `PORT` is `7190` in the `server-owned`, `videoroom` and `recordplay` examples, and `7090` in the `server-shared` example.
+
+Notice that, should you want Janus to send the offer (non-standard WHEP), you can do that by passing an additional `offer=false` to the query string. This is currently required when trying the `videoroom` or `recordplay` demos, as neither the VideoRoom nor the Record&Play plugins support accepting an offer from subscribers: the only plugin that supports that is the Streaming plugin, which is why it's the default when using the WHEP server library.

--- a/examples/recordplay/package.json
+++ b/examples/recordplay/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "janus-whep-recordplay",
+	"description": "WHEP server where the library uses the Record&Play plugin for subscriptions",
+	"type": "module",
+	"keywords": [
+		"whep",
+		"wish",
+		"janus",
+		"recordplay",
+		"webrtc",
+		"meetecho"
+	],
+	"author": {
+		"name": "Lorenzo Miniero",
+		"email": "lorenzo@meetecho.com"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/meetecho/simple-whep-server.git"
+	},
+	"license": "ISC",
+	"private": true,
+	"main": "src/index.js",
+	"dependencies": {},
+	"scripts": {
+		"build": "npm install --omit=dev",
+		"start": "node src/index.js"
+	}
+}

--- a/examples/recordplay/src/index.js
+++ b/examples/recordplay/src/index.js
@@ -1,0 +1,53 @@
+import express from 'express';
+import http from 'http';
+import { JanusWhepServer } from '../../../src/whep.js';
+
+(async function main() {
+	console.log('Example: WHEP server using the Record&Play plugin for subscriptions');
+	let server = null;
+
+	// Create an HTTP server and bind to port 7190 just to list endpoints
+	let myApp = express();
+	myApp.get('/endpoints', async (_req, res) => {
+		res.setHeader('content-type', 'application/json');
+		res.status(200);
+		res.send(JSON.stringify(server.listEndpoints()));
+	});
+	myApp.get('/subscribers', async (_req, res) => {
+		res.setHeader('content-type', 'application/json');
+		res.status(200);
+		res.send(JSON.stringify(server.listSubscribers()));
+	});
+	myApp.use(express.static('../web'));
+	http.createServer({}, myApp).listen(7190);
+
+	// Create a WHEP server, binding to port 7090 and using base path /whep
+	server = new JanusWhepServer({
+		janus: {
+			address: 'ws://localhost:8188'
+		},
+		rest: {
+			port: 7090,
+			basePath: '/whep'
+		}
+	});
+	// Add a couple of global event handlers
+	server.on('janus-disconnected', () => {
+		console.log('WHEP server lost connection to Janus');
+	});
+	server.on('janus-reconnected', () => {
+		console.log('WHEP server reconnected to Janus');
+	});
+	// Start the server
+	await server.start();
+
+	// Create a test endpoint using a static token, and pointing to the
+	// Record&Play recording with ID 1 (assuming it exists)
+	let endpoint = server.createEndpoint({ id: 'abc123', plugin: 'recordplay', feed: 1234, token: 'verysecret' });
+	endpoint.on('new-subscriber', function() {
+		console.log(this.id + ': Endpoint has a new subscriber');
+	});
+	endpoint.on('subscriber-gone', function() {
+		console.log(this.id + ': Endpoint subscriber left');
+	});
+}());

--- a/examples/videoroom/package.json
+++ b/examples/videoroom/package.json
@@ -1,0 +1,29 @@
+{
+	"name": "janus-whep-videoroom",
+	"description": "WHEP server where the library uses the VideoRoom plugin for subscriptions",
+	"type": "module",
+	"keywords": [
+		"whep",
+		"wish",
+		"janus",
+		"videoroom",
+		"webrtc",
+		"meetecho"
+	],
+	"author": {
+		"name": "Lorenzo Miniero",
+		"email": "lorenzo@meetecho.com"
+	},
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/meetecho/simple-whep-server.git"
+	},
+	"license": "ISC",
+	"private": true,
+	"main": "src/index.js",
+	"dependencies": {},
+	"scripts": {
+		"build": "npm install --omit=dev",
+		"start": "node src/index.js"
+	}
+}

--- a/examples/videoroom/src/index.js
+++ b/examples/videoroom/src/index.js
@@ -1,0 +1,53 @@
+import express from 'express';
+import http from 'http';
+import { JanusWhepServer } from '../../../src/whep.js';
+
+(async function main() {
+	console.log('Example: WHEP server using the VideoRoom for subscriptions');
+	let server = null;
+
+	// Create an HTTP server and bind to port 7190 just to list endpoints
+	let myApp = express();
+	myApp.get('/endpoints', async (_req, res) => {
+		res.setHeader('content-type', 'application/json');
+		res.status(200);
+		res.send(JSON.stringify(server.listEndpoints()));
+	});
+	myApp.get('/subscribers', async (_req, res) => {
+		res.setHeader('content-type', 'application/json');
+		res.status(200);
+		res.send(JSON.stringify(server.listSubscribers()));
+	});
+	myApp.use(express.static('../web'));
+	http.createServer({}, myApp).listen(7190);
+
+	// Create a WHEP server, binding to port 7090 and using base path /whep
+	server = new JanusWhepServer({
+		janus: {
+			address: 'ws://localhost:8188'
+		},
+		rest: {
+			port: 7090,
+			basePath: '/whep'
+		}
+	});
+	// Add a couple of global event handlers
+	server.on('janus-disconnected', () => {
+		console.log('WHEP server lost connection to Janus');
+	});
+	server.on('janus-reconnected', () => {
+		console.log('WHEP server reconnected to Janus');
+	});
+	// Start the server
+	await server.start();
+
+	// Create a test endpoint using a static token, and pointing to the
+	// VideoRoom publisher with ID 1 in room 1234 (assuming they exist)
+	let endpoint = server.createEndpoint({ id: 'abc123', plugin: 'videoroom', room: 1234, feed: 1026326423152807, token: 'verysecret' });
+	endpoint.on('new-subscriber', function() {
+		console.log(this.id + ': Endpoint has a new subscriber');
+	});
+	endpoint.on('subscriber-gone', function() {
+		console.log(this.id + ': Endpoint subscriber left');
+	});
+}());

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
 	"dependencies": {
 		"cors": "^2.8.5",
 		"express": "^5.1.0",
-		"janode": "^1.7.4"
+		"janode": "^1.8.0"
 	},
 	"devDependencies": {
 		"@eslint/js": "^9.4.0",


### PR DESCRIPTION
A bit like I've done in https://github.com/meetecho/simple-whip-server/pull/19, this PR aims at making the WHEP module more flexible, by allowing you to use other plugins besides the Streaming plugin as a backend for subscriptions. As a proof-of-concept, this PR adds support for:

* VideoRoom (existing publisher is the source)
* Record&Play (existing recording is the source)

Notice that neither the VideoRoom nor the Record&Play plugin support client-offers for subscriptions, and they probably never will. This means that, to leverage those, you currently need to rely on the non-standard server-offer support in the WHEP module. Should server-offers be supported again in the WHEP specification in the future (which is a concrete possibility), I'll update the code so that the proper way of doing them is implemented.

Considering there's flexibility in which plugins to use, now, the API is a bit rough, as everything is flattened in the same object, which is ugly to see and poor in terms of mantainability/extensibility. Before merging I'll probably change the way you create WHEP endpoints by having plugin-specific objects where you can specify the associated properties (e.g., the room/feed to subscribe for VideoRoom vs. the ID of the recording to play if using Record&Play, for instance).

Notice that, to support the Record&Play plugin. this bumps the Janode requirement to the new v1.8.0.